### PR TITLE
Clean up snapcraft yaml and change build procedures

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -38,17 +38,17 @@ parts:
             - libnss3
             - ca-certificates-java
         
+        override-pull: |
+          snapcraftctl pull
+          snapcraftctl set-version "$(git describe --tags | sed 's/^v//' | cut -d "-" -f2)"
+        
         override-build: |
             curl -sLO http://mirrors.jenkins.io/war/latest/jenkins.war
-            unzip jenkins.war META-INF/MANIFEST.MF
-            VERSION=$(grep Jenkins-Version META-INF/MANIFEST.MF | cut -d' ' -f2 | tr -d '\r')
-            rm META-INF/MANIFEST.MF
             mv $SNAPCRAFT_PART_INSTALL/usr/lib/jvm/java-17-openjdk-* $SNAPCRAFT_PART_INSTALL/usr/lib/jvm/java-17-openjdk
             rm $SNAPCRAFT_PART_INSTALL/usr/lib/jvm/java-17-openjdk/lib/security/cacerts
             cp /etc/ssl/certs/java/cacerts $SNAPCRAFT_PART_INSTALL/usr/lib/jvm/java-17-openjdk/lib/security/cacerts
             cp /etc/ssl/certs/java/cacerts $SNAPCRAFT_PART_INSTALL/etc/ssl/certs/java/cacerts
             mv jenkins.war $SNAPCRAFT_PART_INSTALL
-            snapcraftctl set-version "$VERSION"
                        
     config:
         plugin: dump

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -18,8 +18,7 @@ apps:
           FONTCONFIG_PATH: "$SNAP/etc/fonts"
           JAVA_HOME: "$SNAP/usr/lib/jvm/java-17-openjdk"
           LD_LIBRARY_PATH: "$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET"
-        command: launch
-            
+        command: launch            
         daemon: simple
     config:
         command: jenkins-config
@@ -27,6 +26,7 @@ apps:
 parts:
     jenkins:
         plugin: nil
+        source: https://github.com/jenkinsci/jenkins.git # in lieu of the BGI trigger which didn't seem to work
         stage-packages:
             - fonts-dejavu-core
             - libfontconfig1


### PR DESCRIPTION
Removed process for unzipping .jar file to get version and use git tags instead

Reduces load on build server and build time. Also reduces build-packages count.